### PR TITLE
Reduce Huddle reply model costs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,564 @@
+# Huddle Play Architecture
+
+Status: Current-state review and target-state revamp blueprint
+Reviewed: 2026-07-26
+Repository baseline: `main` at `5a6b78b`
+
+## 1. Executive summary
+
+Huddle Play is an authenticated, AI-assisted reply workspace for relationship-based conversations. A user uploads a conversation screenshot, supplies the intent of their response by typing or speaking, and receives a refined reply shaped by:
+
+- OCR text from the screenshot;
+- the user's draft and requested tone;
+- semantically similar past huddles;
+- a learned writing-style profile;
+- relevant chunks from a document knowledge base.
+
+The app also includes batch reply generation, Instagram Story reply ideas, searchable reply history, style fingerprinting, contact/name inference, and a Trello-like relationship pipeline.
+
+The current system is a React single-page application backed by Supabase Auth, Postgres, Storage, RPC functions, and Edge Functions. OpenAI supplies chat and embedding models, Google Cloud Vision supplies OCR, and Deepgram supplies live transcription.
+
+The core concept is sound, but the implementation has accumulated duplicated paths, oversized modules, partially connected features, privacy risks, and weak server-side authorization boundaries. The target architecture should preserve the useful product behavior while moving identity, retrieval, provider access, persistence, and policy enforcement behind a small authenticated application API.
+
+## 2. Review coverage
+
+The review covered all 180 tracked repository files.
+
+| Area | Coverage | Notes |
+| --- | ---: | --- |
+| React/TypeScript source | 113 files | Entry points, pages, feature components, hooks, services, utilities, generated Supabase types, tests, and 49 UI primitives |
+| Supabase Edge Functions | 11 functions | All handlers, prompts, provider calls, auth handling, persistence, and error behavior |
+| Database migrations | 17 migrations | Tables, policies, storage buckets, vector RPCs, and later schema additions |
+| Domain PDFs | 4 PDFs / 23 pages | DTM, FAQ, MPA, and OLB playbooks; text and rendered pages reviewed |
+| Infrastructure | All tracked files | Vite, TypeScript, Tailwind, Docker, Nginx, Supabase config, environment keys, and deployment metadata |
+| Dependency artifacts | Both lockfiles | `package-lock.json` inspected structurally and audited; legacy binary `bun.lockb` identified and checksummed |
+| Static assets | All assets | Favicon, placeholder SVG, and robots policy reviewed |
+
+Generated UI primitives and generated Supabase types were reviewed as framework artifacts rather than treated as product-specific business logic. Environment values were not reproduced in this document.
+
+## 3. What the current app does
+
+### 3.1 Authentication and entry
+
+- `/` shows a sign-in/sign-up landing page when signed out and the application shell when signed in.
+- Email/password authentication and email confirmation use Supabase Auth.
+- `/flow` is a public-facing product walkthrough, although the global auth wrapper still initializes before rendering it.
+- A role read from `user.user_metadata.role` controls whether document administration is displayed.
+
+### 3.2 Single Huddle reply
+
+1. The user uploads a PNG/JPG conversation screenshot.
+2. The browser optionally crops apparent content on a canvas.
+3. `ocr-extract` sends the image to Google Cloud Vision.
+4. The user types a draft or dictates it through Deepgram.
+5. The browser creates an embedding for the combined screenshot and draft, then searches the global document knowledge RPC.
+6. `enhanced-ai-suggestions` retrieves the user's style profile and similar past huddles.
+7. OpenAI streams a refined reply as newline-delimited JSON.
+8. The browser displays the stream, allows regeneration and tone adjustment, and exposes the huddle/document sources.
+9. The server attempts to embed and store the huddle after streaming completes.
+
+### 3.3 Batch Huddles
+
+- Up to three screenshots can be queued.
+- OCR runs when each file is added.
+- Each item has its own draft, reply, tone, source counts, copy action, and regeneration action.
+- "Generate all" processes the queue sequentially.
+- The settings copy says five screenshots, while the implementation limit is three.
+
+### 3.4 Story interruptions
+
+- Up to five Instagram Story screenshots can be uploaded.
+- Each file is stored in the public `story_images` bucket, OCR'd, and sent to an OpenAI vision-capable model.
+- The function returns short conversation starters grounded in visible story content and, when available, a style profile.
+- The service defaults to three suggestions, while the UI promises five.
+
+### 3.5 History and style learning
+
+- The History tab fetches up to 100 huddles in pages of 25.
+- Huddles are grouped into domain categories such as OLB, MPA, DTM, FAQs, and general conversations.
+- Semantic search uses a query embedding and `match_huddle_plays`.
+- "Refresh my fingerprint" analyzes up to 200 user drafts for:
+  - common topics;
+  - repeated bigrams and trigrams;
+  - repeated sentences;
+  - typical message length;
+  - emoji, punctuation, capitalization, greetings, closings, and slang;
+  - editable personal profile details.
+- The user can review and save the resulting style profile.
+
+### 3.6 Contacts and pipeline
+
+- Names are inferred from OCR using deterministic heuristics, with an LLM fallback for unknown names.
+- Per-name and per-huddle corrections are stored locally and in Supabase.
+- The Trello tab derives contacts from saved huddles and places them in:
+  - conversation stages: Unassigned, OLB, MPA, DTM, STP, Removed;
+  - process stages: Meet and Greet 1/2, FU1/2/3, PRC.
+- Placements persist in both local storage and `trello_board_positions`.
+- `PeopleTab.tsx` implements a separate contact browser but is not reachable from the current navigation.
+
+### 3.7 Knowledge administration
+
+- Admin users can list PDFs in the `documents` storage bucket.
+- The browser downloads and parses PDFs with PDF.js.
+- Content is split by `--- CHUNK N ---` markers, normalized as Markdown, embedded, and inserted one row per marker.
+- Document chunks are globally searchable by authenticated users.
+- Four domain playbooks are committed under `src/Docs`, but they are not imported by the app and therefore are not part of the runtime build. They appear intended as source material for manual storage ingestion.
+
+## 4. Current system context
+
+```mermaid
+flowchart LR
+    U["Authenticated user"] --> SPA["React + Vite SPA"]
+
+    SPA --> AUTH["Supabase Auth"]
+    SPA --> DB["Supabase Postgres + pgvector"]
+    SPA --> STORE["Supabase Storage"]
+    SPA --> EDGE["Supabase Edge Functions"]
+
+    EDGE --> DB
+    EDGE --> STORE
+    EDGE --> OAI["OpenAI chat + embeddings"]
+    EDGE --> GCV["Google Cloud Vision"]
+    EDGE --> DG["Deepgram temporary keys"]
+
+    SPA --> DGSTREAM["Deepgram live transcription"]
+    DGSTREAM --> DG
+
+    DB --> HP["Huddles, profiles, people, pipeline"]
+    DB --> KB["Document chunks + embeddings"]
+    STORE --> DOCS["Public document bucket"]
+    STORE --> STORIES["Public story image buckets"]
+```
+
+## 5. Current reply-generation sequence
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant UI as React UI
+    participant OCR as ocr-extract
+    participant Doc as create-embedding + document RPC
+    participant AI as enhanced-ai-suggestions
+    participant DB as Supabase Postgres
+    participant OpenAI
+
+    User->>UI: Upload screenshot
+    UI->>UI: Optional canvas auto-crop
+    UI->>OCR: Base64 image
+    OCR->>OCR: Google Vision request
+    OCR-->>UI: Extracted text
+
+    User->>UI: Type or dictate draft
+    UI->>Doc: Embed screenshot + draft
+    Doc->>OpenAI: Embedding request
+    Doc-->>UI: Query embedding
+    UI->>DB: search_document_knowledge RPC
+    DB-->>UI: Relevant document chunks
+
+    UI->>AI: Text, draft, and document chunks
+    AI->>DB: Read style profile and similar huddles
+    AI->>OpenAI: Stream refined reply
+    OpenAI-->>AI: Token stream
+    AI-->>UI: NDJSON metadata + tokens
+    UI-->>User: Live reply and sources
+
+    AI->>OpenAI: Reuse/create embedding
+    AI->>DB: Best-effort background huddle insert
+```
+
+## 6. Frontend architecture
+
+### 6.1 Runtime composition
+
+`src/main.tsx` mounts `App.tsx`, which provides:
+
+- TanStack Query;
+- tooltip and toast providers;
+- `AuthWrapper`;
+- React Router.
+
+The signed-in `MainApp` owns two broad state aggregates:
+
+- `useHuddleState` for the reply workflow;
+- `useInterruptions` for Story reply generation.
+
+Four top-level tabs are rendered and force-mounted:
+
+1. Huddle;
+2. Trello;
+3. Interruption;
+4. History.
+
+### 6.2 State model
+
+State is spread across:
+
+- React component state;
+- feature hooks;
+- singleton services such as `ocrService`;
+- browser `localStorage`;
+- Supabase tables;
+- server-side generation state.
+
+Local storage currently retains:
+
+- reply drafts;
+- theme and Huddle mode;
+- obsolete Google OCR settings;
+- people and per-message name overrides;
+- Trello boards, hidden names, activity timestamps, and AI name guesses.
+
+This creates two sources of truth for contacts and board state. Synchronization is implemented independently in `PeopleTab` and `TrelloTab`.
+
+### 6.3 Source reachability
+
+A dependency walk from `src/main.tsx` reaches 74 of 113 TypeScript source files. The remaining 39 include tests, unused shadcn primitives, and dormant product code:
+
+- `PeopleTab.tsx`;
+- `ApiKeyInput.tsx`;
+- `OCRSettings.tsx`;
+- `ThumbsCarousel.tsx`;
+- `useAISuggestions.ts` and `utils/aiSuggestions.ts`;
+- `usePastHuddlesKnowledge.ts`;
+- numerous unused UI primitives.
+
+The dormant files are not inherently harmful, but they obscure the actual product surface and keep unnecessary dependencies in the repository.
+
+### 6.4 Large modules
+
+The most concentrated modules are:
+
+| Module | Approx. lines | Responsibility |
+| --- | ---: | --- |
+| `supabase/functions/enhanced-ai-suggestions/index.ts` | 1,704 | Generation, streaming, retrieval, persistence, tone, style analysis, style writes, and health |
+| `src/components/TrelloTab.tsx` | 1,518 | Contact derivation, name repair, two boards, persistence, drag/drop, and detail UI |
+| `src/components/PastHuddlesTab.tsx` | 1,103 | History, search, categories, virtualization, style analysis editor, and profile preview |
+| `src/components/BatchHuddlesSection.tsx` | 626 | Batch upload, OCR, generation, tone, copying, and queue UI |
+
+These modules cross domain boundaries and are difficult to test independently.
+
+## 7. Backend and provider map
+
+| Edge Function | Current responsibility | Provider/model |
+| --- | --- | --- |
+| `enhanced-ai-suggestions` | Core streaming generation, tone changes, style analysis, style persistence, health | `gpt-5.4-nano` first pass, `gpt-5-mini` regeneration fallback, `gpt-4o-mini` tone adjustment, `text-embedding-3-small` |
+| `ai-suggestions` | Legacy non-streaming generation and tone adjustment | `gpt-5-mini` |
+| `create-embedding` | Search embeddings and document-chunk inserts | `text-embedding-3-small` |
+| `search-past-huddles` | Semantic history search | `text-embedding-3-small` |
+| `ocr-extract` | Google service-account exchange and OCR | Google Cloud Vision |
+| `deepgram-token` | Creates a 10-minute Deepgram key | Deepgram |
+| `generate-story-interruptions` | Story image/text analysis and reply options | `gpt-4o-mini` |
+| `extract-name` | LLM fallback name extraction | `gpt-4o-mini` |
+| `pdf-extract` | Legacy server-side PDF extraction and chunking | Local parsing |
+| `delete-all-documents` | Deletes a user's document rows and user-path storage files | Supabase |
+| `keep-alive` | Calls the enhanced function health action | Supabase |
+
+## 8. Current data architecture
+
+```mermaid
+erDiagram
+    AUTH_USER ||--o{ HUDDLE_PLAY : owns
+    AUTH_USER ||--o| USER_STYLE_PROFILE : has
+    AUTH_USER ||--o{ DOCUMENT_KNOWLEDGE : uploaded_by
+    AUTH_USER ||--o{ PEOPLE_OVERRIDE : owns
+    AUTH_USER ||--o{ HUDDLE_PERSON_OVERRIDE : owns
+    AUTH_USER ||--o{ TRELLO_BOARD_POSITION : owns
+    HUDDLE_PLAY ||--o| HUDDLE_PERSON_OVERRIDE : corrected_by
+
+    HUDDLE_PLAY {
+      uuid id PK
+      uuid user_id
+      text screenshot_text
+      text user_draft
+      text generated_reply
+      text final_reply
+      text selected_tone
+      vector embedding
+      timestamptz created_at
+    }
+
+    USER_STYLE_PROFILE {
+      uuid id PK
+      uuid user_id UK
+      text_array common_topics
+      jsonb common_phrases
+      jsonb common_sentences
+      jsonb style_fingerprint
+      jsonb personal_profile
+    }
+
+    DOCUMENT_KNOWLEDGE {
+      uuid id PK
+      uuid user_id
+      text document_name
+      text content_chunk
+      vector embedding
+      jsonb metadata
+    }
+
+    PEOPLE_OVERRIDE {
+      uuid id PK
+      uuid user_id
+      text raw_name
+      text override
+    }
+
+    HUDDLE_PERSON_OVERRIDE {
+      uuid id PK
+      uuid user_id
+      uuid huddle_play_id
+      text raw_name
+      text override
+    }
+
+    TRELLO_BOARD_POSITION {
+      uuid id PK
+      uuid user_id
+      text name
+      text column_id
+      text mode
+    }
+```
+
+Important schema observations:
+
+- The generated types contain `document_knowledge`, but no checked-in migration creates its base table.
+- Two public Story buckets exist: `story-images` and `story_images`; only the underscore version is used by the frontend.
+- The document bucket is public, including anonymous read access.
+- A later migration intentionally makes document chunks readable to every authenticated user.
+- Vector search functions accept user identity as a parameter rather than deriving it inside the function from `auth.uid()`.
+
+## 9. Deployment architecture
+
+- Vite builds a static SPA.
+- The Dockerfile uses Node 18 to run `npm install` and `npm run build`.
+- Nginx serves the output and falls back to `index.html` for client-side routes.
+- `default.conf.template` expects a runtime `PORT`.
+- The Flow page links to a Railway production URL.
+- There is no checked-in CI workflow, release workflow, automated migration check, or environment contract.
+
+Deployment issues to address:
+
+- `nginx:stable-alpine` does not guarantee that `curl` exists, yet the health check calls it.
+- The build uses `npm install` instead of deterministic `npm ci`.
+- The container is based on Node 18, which is no longer a suitable long-term revamp baseline.
+- The README remains the generic Lovable starter and does not document the real system.
+
+## 10. Validation snapshot
+
+Validation was run against the reviewed commit:
+
+| Check | Result |
+| --- | --- |
+| Production Vite build | Pass |
+| Unit tests | 11/11 pass across two utility test files |
+| ESLint | Fails: 5 errors and 7 warnings |
+| Dependency audit | 19 findings: 1 critical, 14 high, 3 moderate, 1 low |
+| Initial JavaScript bundle | 3,059.66 kB minified / 1,430.48 kB gzip |
+| CSS bundle | 132.47 kB minified / 21.06 kB gzip |
+| Source syntax parse | 126 TS/TSX/JS files parsed with no syntax errors |
+| Targeted type check | Finds unresolved `HuddlePlay` in batch code and missing `documentService.processUploadedFile` |
+
+The Vite build transpiles TypeScript but does not enforce a full type check, so a successful build currently does not imply type correctness.
+
+## 11. Highest-priority current risks
+
+### 11.1 Critical security and privacy risks
+
+1. `ocr-extract` logs the first 50 characters of the Google private key and may log the first 100 characters on failure. The credential should be rotated after the logging is removed.
+2. Several service-role functions trust a client-provided `userId` or `user_id`. This can bypass RLS and risks cross-user reads or writes.
+3. Story images and documents are stored in public buckets. Story files are not removed after generation.
+4. `generate-story-interruptions` can fetch an arbitrary HTTP/HTTPS URL, creating an SSRF boundary.
+5. The frontend decides admin access from mutable user metadata. Authorization must be enforced with server-owned roles or database policies.
+6. Raw screenshots, drafts, document chunks, profile data, and replies are written to application logs in several code paths.
+7. Storage policies allow broadly authenticated users to manage files without an owner-path constraint.
+
+### 11.2 Correctness and reliability risks
+
+1. The core UI never calls `saveCurrentHuddle` or receives the inserted huddle ID from the stream. `currentHuddleId` remains unset, so tone adjustments and regenerations do not update the original record.
+2. Huddle persistence runs as an unregistered background promise after streaming. An Edge runtime may terminate before the insert completes.
+3. Retry composition can trigger up to five server attempts, an automatic second five-attempt pass, and additional batch-level retries. This makes cost and latency unpredictable.
+4. `processUploadedFile` and `docx-extract` are referenced but not implemented in the repository.
+5. `BatchHuddlesSection.tsx` references `HuddlePlay` without importing the type.
+6. The "light" history query still selects full screenshot, draft, and generated-reply text.
+7. Fixed-height virtualization is used for cards whose heights change when expanded.
+8. Deepgram media tracks are not explicitly stopped when recording ends.
+9. OCR processing uses a singleton service and an `O(width * height)` nested boolean matrix for desktop auto-cropping.
+10. Story object URLs and remote files are cleaned up only in some user-driven paths.
+
+### 11.3 Maintainability and product coherence risks
+
+- Two reply engines and multiple search paths coexist.
+- Contact/name logic is duplicated between an unreachable People tab and the Trello tab.
+- There are two toast systems and many unused UI primitives.
+- Product copy and implementation disagree on batch size and Story suggestion count.
+- The four bundled PDFs are disconnected from the ingestion workflow.
+- Large components mix persistence, provider logic, business rules, and rendering.
+- Only name extraction and reply sanitization have unit tests.
+- No analytics distinguish generated, accepted, copied, regenerated, or abandoned replies.
+
+## 12. Target architecture
+
+### 12.1 Design principles
+
+1. Derive identity on the server from the verified access token.
+2. Store personal conversation media privately and for the shortest practical period.
+3. Create a Huddle record before generation so every OCR result, generation, source, and final user action has a durable ID.
+4. Keep retrieval and prompt construction server-side.
+5. Separate provider adapters from product policy.
+6. Treat "accepted/copied by the user" as the learning signal, not every generated draft.
+7. Make all generation operations idempotent, cancellable, observable, and cost-bounded.
+8. Split the UI by product domain, with server state managed consistently through TanStack Query.
+
+### 12.2 Proposed system
+
+```mermaid
+flowchart LR
+    U["User"] --> WEB["Modular React app"]
+    WEB --> API["Authenticated Huddle API"]
+
+    API --> AUTH["Supabase Auth"]
+    API --> DB["Postgres + pgvector"]
+    API --> PRIVATE["Private Storage"]
+    API --> JOBS["Ingestion / cleanup jobs"]
+    API --> AI["AI orchestration"]
+
+    AI --> CHAT["Chat model adapter"]
+    AI --> EMBED["Embedding adapter"]
+    AI --> OCR["OCR adapter"]
+    AI --> SPEECH["Speech adapter"]
+
+    JOBS --> PRIVATE
+    JOBS --> DB
+
+    API --> OBS["Redacted logs, traces, metrics"]
+    WEB --> ANALYTICS["Product analytics without message content"]
+```
+
+### 12.3 Target domain modules
+
+```text
+src/
+  app/                 routing, providers, layout
+  features/
+    auth/
+    huddles/           capture, OCR review, draft, generation, acceptance
+    history/           search, detail, deletion
+    style-profile/     analysis, review, settings
+    contacts/          inferred contact, correction, history
+    pipeline/          stage definitions and positions
+    knowledge/         documents, chunks, ingestion status
+    story-replies/     optional source type within the composer
+    batch/             queue built on the same Huddle API
+  shared/
+    api/
+    ui/
+    validation/
+    telemetry/
+
+supabase/
+  functions/
+    huddles-create/
+    huddles-ocr/
+    huddles-generate/
+    huddles-accept/
+    huddles-search/
+    style-profile/
+    documents-ingest/
+    speech-token/
+  migrations/
+```
+
+The exact number of Edge Functions can be reduced if a small router is preferred, but each handler should have one authorization model and one bounded responsibility.
+
+### 12.4 Target Huddle lifecycle
+
+1. `POST /huddles` creates a draft Huddle and returns `huddle_id`.
+2. The screenshot is uploaded to a private, owner-scoped path or sent directly for OCR.
+3. OCR text is persisted against the Huddle and shown to the user for correction.
+4. `POST /huddles/{id}/generations` performs server-side retrieval and begins a stream.
+5. Each generation stores:
+   - prompt version;
+   - provider/model;
+   - retrieval source IDs and scores;
+   - latency and token/cost metadata;
+   - generated reply;
+   - status and error code.
+6. Regeneration and tone changes create child generations instead of mutating history.
+7. Copy/accept records the selected generation and final user-edited text.
+8. Only accepted text feeds style analysis and similarity memory.
+9. Temporary media is automatically deleted.
+
+### 12.5 Target data model
+
+Recommended additions and changes:
+
+- `huddles`: durable workflow record with user, contact, source type, OCR text, user intent, and status.
+- `huddle_media`: private object reference, media type, deletion time, and processing status.
+- `generations`: immutable generation attempts with parent/variant relationship and model metadata.
+- `generation_sources`: join table to past huddles and document chunks.
+- `contacts`: first-class contact identity instead of inferred names as board keys.
+- `contact_aliases`: raw OCR names and corrected aliases.
+- `pipeline_stages` and `contact_pipeline_positions`: typed, configurable stages.
+- `knowledge_documents`: owner/workspace, storage path, status, checksum, and version.
+- `knowledge_chunks`: document FK, content, embedding, page/line metadata.
+- `style_profiles`: versioned profile derived from accepted replies, plus user-edited settings.
+- `user_roles`: server-owned role assignments, or equivalent `app_metadata`.
+
+Existing data can be migrated incrementally. `huddle_plays` can remain readable while new writes target the new schema.
+
+### 12.6 API and policy requirements
+
+- Every handler verifies the bearer token.
+- User IDs are never accepted as authority from request bodies.
+- RPCs use `auth.uid()` or receive identity only from a trusted service layer.
+- Zod or an equivalent schema validates all requests and responses.
+- Rate limits are applied per user and per operation.
+- Provider timeouts and retries are centralized and capped.
+- Raw content is redacted from logs by default.
+- Storage is private and uses signed URLs only when necessary.
+- CORS is restricted to configured origins.
+- Prompt templates and safety rules are versioned and testable.
+- Search returns IDs and short previews first; full content is hydrated only when opened.
+
+## 13. Migration plan
+
+### Phase 0: Contain risk
+
+- Remove all credential and raw-message logging.
+- Rotate the Google service-account key.
+- Make Story and document storage private.
+- Bind every service-role operation to the authenticated user.
+- Block arbitrary Story image URLs.
+- Add rate limits and bounded retries.
+
+### Phase 1: Stabilize the core loop
+
+- Introduce a durable Huddle ID before OCR/generation.
+- Consolidate to one generation API and one retrieval path.
+- Persist every generation and acceptance deterministically.
+- Add type checking, CI, integration tests, and provider mocks.
+- Split and lazy-load the initial bundle.
+
+### Phase 2: Rebuild personalization
+
+- Train the style profile only from accepted or edited replies.
+- Move document retrieval fully server-side.
+- Add clear source provenance and relevance behavior.
+- Migrate contacts and pipeline positions to first-class IDs.
+
+### Phase 3: Restore secondary workflows
+
+- Rebuild batch generation on the same Huddle state machine.
+- Fold Story replies into a source-type mode with private temporary media.
+- Reintroduce only the document administration and contact UI that users actually need.
+
+## 14. Architectural decisions to confirm
+
+1. Is the product individual-only, or should the revamp support teams/coaches and shared knowledge?
+2. Are the OLB/MPA/DTM/FAQ playbooks global product knowledge or private user documents?
+3. Is the relationship pipeline a core product pillar or an optional companion workflow?
+4. Should Story replies remain a primary workflow?
+5. What message/media retention period is acceptable?
+6. Which provider requirements are fixed versus replaceable?
+7. Does the product need subscription plans, usage quotas, or administrator-managed invitations?

--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,500 @@
+# Huddle Play Revamp PRD
+
+Status: Draft for product validation
+Date: 2026-07-26
+Architecture reference: `ARCHITECTURE.md`
+
+## 1. Product decision
+
+Revamp Huddle Play around one dependable promise:
+
+> Turn a conversation screenshot and the user's intent into a human, context-aware reply that the user remains fully in control of.
+
+The revamp should prioritize the core reply loop before restoring batch, Story, contact, and pipeline breadth. The existing app proves the useful ingredients, but the new product should feel like one coherent assistant rather than several adjacent tools.
+
+## 2. Positioning assumption
+
+The current prompts, pipeline stages, and bundled playbooks indicate a primary audience of relationship-based sellers and network marketers who use social conversations to build rapport, discuss mentorship, and guide contacts through OLB, MPA, DTM, and follow-up stages.
+
+This audience and terminology must be validated before finalizing the redesign. If the intended market is broader, the workflow should retain configurable playbooks and pipeline stages while removing niche terminology from the default experience.
+
+## 3. Problem
+
+Users handle many nuanced conversations across social and messaging apps. They want to respond quickly without sounding scripted, overly sales-focused, or unlike themselves.
+
+Today they must:
+
+- interpret a screenshot;
+- remember prior context and relevant playbook guidance;
+- decide what they intend to communicate;
+- write a concise, natural reply;
+- keep track of the person and the conversation stage;
+- repeat this across many conversations.
+
+Generic AI chat tools can write text, but they do not reliably combine the user's voice, the current screenshot, approved knowledge, prior accepted replies, and a relationship workflow. The existing Huddle Play implementation attempts to combine these signals, but reliability, privacy, and product coherence prevent it from being a trustworthy daily tool.
+
+## 4. Vision
+
+Huddle Play should feel like a private reply copilot:
+
+- fast enough to use in the middle of a conversation;
+- grounded enough to trust;
+- personal enough to sound like the user;
+- transparent enough to show what informed the reply;
+- structured enough to learn from accepted replies and maintain contact continuity;
+- safe enough for private conversations and screenshots.
+
+## 5. Goals
+
+### 5.1 Product goals
+
+1. Reduce the time and mental effort required to craft a high-quality reply.
+2. Improve confidence that replies are clear, authentic, and aligned with the user's intent.
+3. Build personalization from replies the user actually accepts or edits.
+4. Preserve relevant continuity across conversations without leaking another user's data.
+5. Make grounding sources understandable and controllable.
+6. Give users a lightweight way to track the people and stages connected to their huddles.
+
+### 5.2 Revamp goals
+
+1. Replace fragmented generation paths with one observable Huddle lifecycle.
+2. Establish privacy, authorization, retention, and cost controls as launch requirements.
+3. Make the core experience mobile-first and accessible.
+4. Create a modular foundation for batch and Story workflows.
+5. Add enough measurement to determine whether the assistant is genuinely useful.
+
+## 6. Non-goals for the first release
+
+- Automatically sending messages on the user's behalf.
+- Connecting directly to Instagram, WhatsApp, Messenger, or other inboxes.
+- A general-purpose CRM.
+- Team collaboration, manager dashboards, or coach review unless validated as essential.
+- Fully autonomous lead qualification.
+- Training or fine-tuning a proprietary foundation model.
+- Rebuilding every dormant or experimental feature from the current repository.
+
+## 7. Users and jobs to be done
+
+### 7.1 Primary user: relationship builder
+
+The user regularly responds to contacts on social or messaging platforms and wants to maintain warmth, momentum, and authenticity.
+
+Jobs:
+
+- "When I receive a message, help me understand the context and write a reply that sounds like me."
+- "When I know what I want to say but cannot phrase it well, refine my intent without changing it."
+- "When a contact asks a detailed question, bring in the right approved information without making claims up."
+- "When I have spoken to someone before, help me continue naturally."
+
+### 7.2 Secondary user: high-volume operator
+
+The user has several conversations to work through in one session.
+
+Jobs:
+
+- "Let me queue several screenshots and process them without losing track."
+- "Show which items need input, are generating, failed, or are ready."
+
+### 7.3 Optional user: knowledge administrator
+
+The user or product administrator maintains approved playbooks and reference documents.
+
+Jobs:
+
+- "Upload and verify knowledge that may inform replies."
+- "See ingestion status and replace outdated versions."
+- "Control whether knowledge is global, workspace-level, or private."
+
+## 8. Product principles
+
+1. Human in control: never send automatically; make edit, regenerate, accept, and copy explicit.
+2. Intent before invention: improve what the user wants to say without manufacturing claims.
+3. Accepted behavior is the signal: learn from selected or edited replies, not every model output.
+4. Progressive context: reveal OCR, sources, and history when useful without overwhelming the composer.
+5. Privacy by default: private storage, short retention, server-derived identity, and no raw-content logs.
+6. One workflow, multiple inputs: screenshot, pasted text, and Story should share the same underlying Huddle lifecycle.
+7. Clear recovery: failures explain what happened and offer a bounded retry.
+
+## 9. Proposed information architecture
+
+### 9.1 Primary navigation
+
+1. Reply
+   - new Huddle;
+   - screenshot or pasted-text input;
+   - typed or dictated intent;
+   - generation, sources, and acceptance.
+2. History
+   - recent Huddles;
+   - search and filters;
+   - accepted reply and source detail;
+   - style profile.
+3. Contacts
+   - inferred contacts and aliases;
+   - conversation history;
+   - optional pipeline view.
+4. Knowledge
+   - approved documents;
+   - ingestion and version status;
+   - access scope.
+5. Settings
+   - account, privacy, retention, style preferences, usage.
+
+Batch should initially be an action within Reply, not a separate product. Story reply should be an input mode within Reply once restored.
+
+### 9.2 Simplifications from the current app
+
+- Merge People and Trello contact logic into one Contacts domain.
+- Merge style analysis into History/Settings instead of a large modal embedded in History.
+- Remove obsolete client API-key settings.
+- Remove the legacy AI suggestion path.
+- Use one toast/notification system.
+- Keep generated UI primitives only when used.
+
+## 10. Core user journey
+
+```mermaid
+flowchart LR
+    A["Start a Huddle"] --> B["Add screenshot or text"]
+    B --> C["Review OCR and contact"]
+    C --> D["Type or dictate intent"]
+    D --> E["Generate reply"]
+    E --> F["Review reply and sources"]
+    F --> G{"Good enough?"}
+    G -- "Edit / tone / regenerate" --> E
+    G -- "Yes" --> H["Accept and copy"]
+    H --> I["Save history and update contact continuity"]
+```
+
+### 10.1 Happy path
+
+1. The user opens Reply.
+2. The user uploads a screenshot.
+3. OCR begins immediately and displays progress.
+4. The extracted text and inferred contact appear in a compact review step.
+5. The user corrects either if needed.
+6. The user types or dictates their intent.
+7. Huddle Play streams a reply.
+8. The user can inspect the few sources that materially influenced it.
+9. The user edits, changes tone, or requests a different angle.
+10. The user accepts and copies the reply.
+11. The accepted text becomes history and personalization evidence.
+
+### 10.2 Failure path
+
+- OCR failure allows retry, manual paste, or proceeding without a screenshot.
+- Generation failure preserves the user's work and offers one explicit retry.
+- A timeout can be cancelled and restarted without creating duplicate records.
+- If retrieval is unavailable, the reply can proceed without sources and clearly says so.
+- The app never displays a generic generated fallback as if it were a successful reply.
+
+## 11. Functional requirements
+
+Priority definitions:
+
+- P0: required for a safe, usable core launch.
+- P1: required for the complete revamp experience.
+- P2: follow-up after core quality is proven.
+
+| ID | Priority | Requirement | Acceptance criteria |
+| --- | --- | --- | --- |
+| FR-01 | P0 | Account access | Users can sign up, verify, sign in, sign out, and recover access. Protected data is inaccessible without a valid session. |
+| FR-02 | P0 | Create Huddle | Starting a reply immediately creates a durable user-owned Huddle ID and draft status. |
+| FR-03 | P0 | Screenshot input | Users can upload PNG/JPG/HEIC within a documented limit, see a preview, replace it, or remove it. |
+| FR-04 | P0 | Pasted context | Users can paste conversation text instead of uploading an image. |
+| FR-05 | P0 | OCR review | OCR text is shown for review and can be corrected before generation. OCR failure never destroys the image or draft. |
+| FR-06 | P0 | Intent draft | Users can type an intent/draft, and it is preserved during recoverable failures. |
+| FR-07 | P1 | Voice draft | Users can dictate intent, see interim text, stop recording, and edit the transcript. Microphone access ends when recording stops. |
+| FR-08 | P0 | Generate reply | The app streams one reply based on the reviewed context and user intent. Empty, trivial, or invalid input receives clear validation. |
+| FR-09 | P0 | Grounded retrieval | Retrieval occurs on the server and only includes authorized document chunks and accepted past replies relevant to the current Huddle. |
+| FR-10 | P0 | Source transparency | The UI shows source type, title/date, and a short preview for sources actually supplied to the model. |
+| FR-11 | P0 | Edit and accept | Users can directly edit the reply, accept it, and copy it. The accepted text is stored separately from raw model output. |
+| FR-12 | P1 | Variants | Users can request a different angle or tone without losing prior generations. |
+| FR-13 | P0 | History | Users can view, search, open, and delete their Huddles. Lists use lightweight previews and hydrate full details on demand. |
+| FR-14 | P1 | Style profile | Users can view and edit explicit style preferences. Derived style is built only from accepted/edited replies. |
+| FR-15 | P1 | Contact inference | A contact can be inferred from OCR, corrected by the user, and linked through a stable contact ID. |
+| FR-16 | P1 | Contact continuity | A contact detail view shows relevant prior Huddles and the latest accepted reply. |
+| FR-17 | P1 | Pipeline | Contacts can be moved between configurable stages, with one authoritative server-side position. |
+| FR-18 | P1 | Knowledge ingestion | Authorized users can upload supported documents, see ingestion progress, inspect extracted chunks, replace a version, and delete it. |
+| FR-19 | P1 | Knowledge scope | Every document is explicitly global, workspace-scoped, or private. The UI displays the scope. |
+| FR-20 | P2 | Batch queue | Users can queue a configurable number of Huddles, monitor per-item state, and run bounded sequential or low-concurrency generation. |
+| FR-21 | P2 | Story reply mode | Users can submit a Story screenshot and receive distinct, visually grounded starters through the same Huddle record. |
+| FR-22 | P0 | Data controls | Users can delete individual Huddles and request deletion/export of their account data. |
+| FR-23 | P0 | Usage feedback | Generation, OCR, and provider failures use stable error codes and actionable user-facing messages. |
+
+## 12. AI and retrieval requirements
+
+### 12.1 Input hierarchy
+
+The reply composer should apply evidence in this order:
+
+1. reviewed conversation context;
+2. user's stated intent;
+3. explicit style preferences;
+4. accepted replies from relevant prior Huddles;
+5. authorized document knowledge;
+6. general model writing ability.
+
+No retrieved source may override the user's intent or system policy.
+
+### 12.2 Generation policy
+
+- Treat screenshot, pasted text, drafts, and documents as untrusted content.
+- Never follow instructions embedded inside those sources.
+- Do not invent facts, business claims, numbers, offers, guarantees, or outcomes.
+- Preserve the user's intent.
+- Do not introduce greetings, closings, emojis, or sales pressure unless supported by the draft or explicit style settings.
+- Return reply text plus structured metadata, never an untyped mixed payload.
+- Version the system prompt and retrieval policy.
+
+### 12.3 Retrieval policy
+
+- Query text is generated server-side from the reviewed context and intent.
+- Past-Huddle search is restricted to the authenticated user's accepted replies.
+- Knowledge search is restricted to authorized scopes.
+- Retrieval results include a score, source ID, version, and location metadata.
+- Low-confidence results are excluded.
+- The application records which sources were supplied to each generation.
+- Full source content is not sent back to the client unless the user opens it.
+
+### 12.4 Reliability and cost controls
+
+- One initial generation plus at most one automatic retry for a retryable provider failure.
+- User-requested regeneration is a new operation with its own idempotency key.
+- Every provider call has an explicit timeout and cancellation path.
+- Per-user rate and spend limits are enforced.
+- Token budgets are based on a bounded context assembly policy.
+- Failed or cancelled generations are stored with status, not as successful replies.
+
+### 12.5 Evaluation set
+
+Before launch, create a de-identified evaluation set covering:
+
+- short and long screenshots;
+- poor OCR;
+- prompt injection inside screenshot text;
+- unanswered FAQs;
+- relevant and irrelevant playbook chunks;
+- warm, professional, direct, and casual styles;
+- slang and punctuation preservation;
+- contact continuity;
+- refusal to invent unsupported claims;
+- Story images with ambiguous content.
+
+## 13. Privacy and security requirements
+
+These are release blockers, not follow-up improvements.
+
+1. All message screenshots and Story images are private.
+2. Uploaded media is deleted immediately after processing when possible and no later than 24 hours by default.
+3. Raw conversation content, document text, credentials, tokens, and model prompts are not written to logs.
+4. Server handlers derive the user from the verified access token.
+5. Client-provided user IDs are ignored for authorization.
+6. Admin roles use server-owned role data and are enforced server-side.
+7. Storage paths and policies enforce ownership or explicit workspace scope.
+8. Document access scope is testable through RLS.
+9. Arbitrary server-side URL fetching is disabled or restricted to signed, allowlisted storage URLs.
+10. CORS uses environment-specific allowlists.
+11. Secrets are never committed to the repository or returned to the browser.
+12. User data deletion removes database rows, embeddings, and stored media.
+13. Provider agreements and retention settings are documented before production launch.
+
+## 14. UX requirements
+
+### 14.1 Mobile-first
+
+- The entire happy path works on a current mobile browser.
+- Primary actions remain reachable above the safe-area inset.
+- The user can review the screenshot and draft without excessive scrolling.
+- Loading states remain inline and do not block unrelated actions.
+
+### 14.2 Accessibility
+
+- Meet WCAG 2.2 AA for contrast, focus, labels, keyboard behavior, and motion preferences.
+- All icon-only actions have accessible names.
+- Carousels are not required to consume core content.
+- Reduced-motion settings disable decorative movement.
+- Error and progress states are announced to assistive technology.
+
+### 14.3 Trust cues
+
+- Display "AI-generated" and preserve the human approval step.
+- Clearly label inferred OCR/contact data as editable.
+- Show why a source appeared.
+- Distinguish generated, edited, and accepted text.
+- Never claim a Huddle was saved until persistence is confirmed.
+
+## 15. Non-functional requirements
+
+Proposed launch gates:
+
+| Category | Target |
+| --- | --- |
+| Availability | 99.5% monthly for authenticated core reply operations |
+| OCR success | At least 95% of legible evaluation screenshots produce usable text or a recoverable manual path |
+| Generation success | At least 99% of valid requests return a reply or actionable failure without duplicate billing |
+| Time to first token | P50 under 4 seconds and P95 under 8 seconds after retrieval completes |
+| End-to-end generation | P95 under 20 seconds excluding user input |
+| Initial JS | Under 400 kB gzip for the signed-out route; heavy features lazy-loaded |
+| Data isolation | Automated cross-user access tests pass for every table, RPC, storage bucket, and Edge Function |
+| Tests | Unit tests for domain rules; integration tests for auth/retrieval/persistence; browser tests for the happy path |
+| Observability | Request ID, stage timing, provider status, token/cost estimate, and redacted error code for every generation |
+| Browser support | Current and previous major Safari, Chrome, Edge, and mobile equivalents |
+
+## 16. Success metrics
+
+### 16.1 North-star metric
+
+Accepted Huddles per weekly active user.
+
+An accepted Huddle is one where the user explicitly accepts or copies a reply after generation. Copy alone should be instrumented carefully so accidental copies do not overstate value.
+
+### 16.2 Activation
+
+- Percentage of new users who accept their first reply in the first session.
+- Median time from account creation to first accepted reply.
+- Percentage of uploads that reach a successful OCR review.
+
+### 16.3 Quality
+
+- First-generation acceptance rate.
+- Regeneration rate.
+- Average edit distance between generated and accepted reply.
+- Source-open rate and source-dismiss rate.
+- User quality rating or "sounds like me" feedback.
+
+### 16.4 Reliability and cost
+
+- OCR, retrieval, generation, and persistence failure rates.
+- P50/P95 latency by stage.
+- Duplicate generation rate.
+- Cost per accepted Huddle.
+- Automatic retry rate.
+
+### 16.5 Retention
+
+- Weekly retained users who accepted a reply.
+- Accepted Huddles per retained user.
+- Percentage of users with an active style profile after sufficient accepted replies.
+
+## 17. Analytics events
+
+Events must exclude raw message content.
+
+- `huddle_created`
+- `source_uploaded`
+- `ocr_started`
+- `ocr_completed`
+- `ocr_corrected`
+- `draft_entered`
+- `voice_started`
+- `voice_completed`
+- `generation_started`
+- `generation_first_token`
+- `generation_completed`
+- `generation_failed`
+- `source_opened`
+- `variant_requested`
+- `reply_edited`
+- `reply_accepted`
+- `reply_copied`
+- `huddle_deleted`
+- `contact_corrected`
+- `pipeline_stage_changed`
+- `document_ingestion_started`
+- `document_ingestion_completed`
+- `document_ingestion_failed`
+
+Each event should include only IDs, timestamps, stage durations, source type, model/prompt version, and non-content status metadata.
+
+## 18. Delivery plan
+
+### Phase 0: Security and product validation
+
+- Confirm target audience and terminology.
+- Remove sensitive logging and rotate exposed-risk credentials.
+- Lock down storage, RLS, RPCs, and Edge Functions.
+- Define retention and provider policies.
+- Instrument the current happy path to establish baselines.
+
+Exit criteria:
+
+- No known cross-user access path.
+- No public conversation media.
+- No credential or raw-message logging.
+- Agreed primary persona and first-release scope.
+
+### Phase 1: Core revamp
+
+- New mobile-first Reply flow.
+- Durable Huddle and generation records.
+- OCR review and pasted-text fallback.
+- One streaming generation service.
+- Accept/edit/copy behavior.
+- Lightweight History.
+- CI, type check, integration tests, and observability.
+
+Exit criteria:
+
+- Core launch gates in Sections 13 and 15 pass.
+- Evaluation set meets the agreed quality threshold.
+- Persistence is deterministic across generation, regeneration, and acceptance.
+
+### Phase 2: Personalization and knowledge
+
+- Accepted-reply style profile.
+- Server-side document ingestion and scoped retrieval.
+- Source details and retrieval controls.
+- Contacts and corrected aliases.
+
+Exit criteria:
+
+- Retrieval precision and cross-user isolation tests pass.
+- Personalization demonstrates improvement over the non-personalized baseline.
+
+### Phase 3: Workflow expansion
+
+- Configurable pipeline.
+- Batch queue.
+- Story reply mode.
+- Usage plans and admin controls if required.
+
+Exit criteria:
+
+- Each feature reuses the Huddle lifecycle and does not introduce a parallel persistence or authorization model.
+
+## 19. Risks and mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Niche terminology limits market | Positioning and onboarding may confuse broader users | Validate the primary segment; make playbooks and stages configurable |
+| Personalization amplifies poor outputs | Replies may become less safe or authentic | Learn only from accepted/edited replies; expose style controls; evaluate changes |
+| OCR errors distort context | Bad replies or wrong contact inference | OCR review step, manual correction, pasted-text fallback |
+| Retrieval surfaces irrelevant scripts | Replies feel manipulative or inaccurate | Higher-quality chunking, scoped retrieval, thresholds, source visibility, evaluations |
+| AI costs rise with history and documents | Unsustainable unit economics | Context budgets, result caching, rate limits, cost per accepted Huddle metric |
+| Pipeline scope distracts from core value | Revamp becomes another CRM project | Ship after core acceptance and retention are validated |
+| Users expect automatic sending | Trust or compliance concerns | Explicitly position as a human-approved drafting tool |
+
+## 20. Open product questions
+
+1. Who is the first paying user: an individual operator, a coach, or a team?
+2. Which existing feature is used most today: single reply, batch, Story, History, or Trello?
+3. Are OLB, MPA, DTM, and FAQ universal product stages or one organization's playbook?
+4. Should every user share the same knowledge documents, or bring their own?
+5. How long should conversation text be retained?
+6. Should copied text automatically count as accepted, or require an explicit "Use reply" action?
+7. Is contact/pipeline management essential to the product promise?
+8. What is the acceptable per-user AI cost?
+9. Are there compliance or consent requirements for uploading other people's messages?
+10. Should the revamp preserve Lovable/Railway/Supabase deployment constraints?
+
+## 21. Definition of done for the PRD
+
+This PRD is ready for implementation planning when:
+
+- the primary persona and positioning assumption are confirmed;
+- P0/P1 scope is approved;
+- knowledge ownership and document scope are decided;
+- privacy retention is agreed;
+- the core success metric and launch targets are accepted;
+- the target architecture and migration sequence are approved.

--- a/src/utils/huddleModelRouting.test.ts
+++ b/src/utils/huddleModelRouting.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  HUDDLE_MODELS,
+  selectHuddleReplyModel,
+} from "../../supabase/functions/shared/huddleModelRouting";
+
+describe("selectHuddleReplyModel", () => {
+  it("uses the intended provider model IDs", () => {
+    expect(HUDDLE_MODELS).toEqual({
+      primaryReply: "gpt-5.4-nano",
+      fallbackReply: "gpt-5-mini",
+      toneAdjustment: "gpt-4o-mini",
+    });
+  });
+
+  it("uses the cost-efficient model without reasoning for a simple first pass", () => {
+    expect(
+      selectHuddleReplyModel({
+        isRegeneration: false,
+        contextIsHeavy: false,
+      })
+    ).toEqual({
+      model: HUDDLE_MODELS.primaryReply,
+      reasoningEffort: "none",
+      route: "primary",
+    });
+  });
+
+  it("uses low reasoning when the first pass has substantial context", () => {
+    expect(
+      selectHuddleReplyModel({
+        isRegeneration: false,
+        contextIsHeavy: true,
+      })
+    ).toEqual({
+      model: HUDDLE_MODELS.primaryReply,
+      reasoningEffort: "low",
+      route: "primary",
+    });
+  });
+
+  it("uses GPT-5 mini as the quality fallback for regenerations", () => {
+    expect(
+      selectHuddleReplyModel({
+        isRegeneration: true,
+        contextIsHeavy: false,
+      })
+    ).toEqual({
+      model: HUDDLE_MODELS.fallbackReply,
+      reasoningEffort: "medium",
+      route: "fallback",
+    });
+  });
+});

--- a/supabase/functions/enhanced-ai-suggestions/index.ts
+++ b/supabase/functions/enhanced-ai-suggestions/index.ts
@@ -1,5 +1,9 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import supabaseJs from "https://esm.sh/@supabase/supabase-js@2.50.0/dist/umd/supabase.js?target=deno&deno-std=0.168.0";
+import {
+  HUDDLE_MODELS,
+  selectHuddleReplyModel,
+} from "../shared/huddleModelRouting.ts";
 import { stopWords } from "../shared/stopWords.ts";
 
 const { createClient } = supabaseJs;
@@ -1035,18 +1039,28 @@ Refine this draft to make it better without inventing missing details.`;
       console.log("🧾 DEBUG: screenshotText:", screenshotText);
       console.log("🧾 DEBUG: userDraft:", userDraft);
 
-      // Use gpt-5-mini; bump token budget when context is heavy so style/continuity stay accurate.
+      // Keep the first pass cost-efficient, then use GPT-5 mini when the user
+      // regenerates or the client falls back after a failed first pass.
       const contextIsHeavy =
         contextFromDocuments.length > 0 ||
         contextFromPastHuddles.length > 0 ||
         continuityContext.length > 0 ||
         systemPrompt.length + userPrompt.length > 7000;
-      const chatModel = "gpt-5-mini";
+      const {
+        model: chatModel,
+        reasoningEffort,
+        route: modelRoute,
+      } = selectHuddleReplyModel({
+        isRegeneration: Boolean(isRegeneration),
+        contextIsHeavy,
+      });
       const maxTokens = contextIsHeavy ? 1200 : 1000;
 
       console.log("🧠 DEBUG: Model selection:", {
         contextIsHeavy,
         chatModel,
+        reasoningEffort,
+        modelRoute,
         maxTokens,
       });
 
@@ -1061,6 +1075,8 @@ Refine this draft to make it better without inventing missing details.`;
           pastHuddles: pastHuddlesForDisplay,
           documentKnowledge: documentKnowledge || [],
           slangAddressTerms,
+          generationModel: chatModel,
+          modelRoute,
         }) + "\n"
       );
 
@@ -1073,6 +1089,7 @@ Refine this draft to make it better without inventing missing details.`;
           { role: "user", content: userPrompt },
         ],
         max_completion_tokens: maxTokens,
+        reasoning_effort: reasoningEffort,
         stream: true,
       };
 
@@ -1644,7 +1661,7 @@ Refine this draft to make it better without inventing missing details.`;
         });
       }
 
-      const toneModel = "gpt-5-mini";
+      const toneModel = HUDDLE_MODELS.toneAdjustment;
       const toneRequestBody: Record<string, unknown> = {
         model: toneModel,
         messages: [

--- a/supabase/functions/shared/huddleModelRouting.ts
+++ b/supabase/functions/shared/huddleModelRouting.ts
@@ -1,0 +1,36 @@
+export const HUDDLE_MODELS = {
+  primaryReply: "gpt-5.4-nano",
+  fallbackReply: "gpt-5-mini",
+  toneAdjustment: "gpt-4o-mini",
+} as const;
+
+export type HuddleReplyRoute = "primary" | "fallback";
+export type HuddleReasoningEffort = "none" | "low" | "medium";
+
+type SelectHuddleReplyModelOptions = {
+  isRegeneration: boolean;
+  contextIsHeavy: boolean;
+};
+
+export function selectHuddleReplyModel({
+  isRegeneration,
+  contextIsHeavy,
+}: SelectHuddleReplyModelOptions): {
+  model: string;
+  reasoningEffort: HuddleReasoningEffort;
+  route: HuddleReplyRoute;
+} {
+  if (isRegeneration) {
+    return {
+      model: HUDDLE_MODELS.fallbackReply,
+      reasoningEffort: "medium",
+      route: "fallback",
+    };
+  }
+
+  return {
+    model: HUDDLE_MODELS.primaryReply,
+    reasoningEffort: contextIsHeavy ? "low" : "none",
+    route: "primary",
+  };
+}


### PR DESCRIPTION
## What changed

- Route first-pass Huddle replies through `gpt-5.4-nano`.
- Use no reasoning for simple requests and low reasoning for context-heavy requests.
- Retain `gpt-5-mini` at medium reasoning for regenerations and fallback quality.
- Move tone-only adjustments to `gpt-4o-mini`.
- Centralize model routing and add focused tests.
- Add the current/target architecture review and revamp PRD.

## Why

The active Huddle flow used `gpt-5-mini` for every generation and tone adjustment. The new routing lowers routine generation cost while preserving the existing model as a quality fallback when a user regenerates.

## Impact

Initial replies should cost less and remain fast. Regeneration continues to use the previous model profile, and the response streaming contract is unchanged.

## Validation

- `npm run build`
- `npm test` — 15 tests passed
- Focused ESLint checks for all changed TypeScript files
- Diff and whitespace checks