### PR TITLE
Bound Huddle generation retries

### DIFF
--- a/src/components/BatchHuddlesSection.tsx
+++ b/src/components/BatchHuddlesSection.tsx
@@ -216,33 +216,25 @@ export const BatchHuddlesSection = ({
       error: undefined,
     }));
 
-    let result = null;
     let latestSlangTerms: string[] | undefined;
-    for (let attempt = 1; attempt <= 2; attempt++) {
-      result = await generateReply(
-        screenshotText,
-        draftForAI,
-        isRegeneration,
-        target.documents,
-        target.pastHuddles,
-        (partial, meta) => {
-          if (meta?.slangAddressTerms?.length) {
-            latestSlangTerms = meta.slangAddressTerms;
-          }
-          updateItem(id, (item) => ({
-            ...item,
-            reply: sanitizeHumanReply(partial, {
-              slangAddressTerms: latestSlangTerms,
-            }),
-          }));
+    const result = await generateReply(
+      screenshotText,
+      draftForAI,
+      isRegeneration,
+      target.documents,
+      target.pastHuddles,
+      (partial, meta) => {
+        if (meta?.slangAddressTerms?.length) {
+          latestSlangTerms = meta.slangAddressTerms;
         }
-      );
-
-      if (result) break;
-      if (attempt === 1) {
-        await wait(250);
+        updateItem(id, (item) => ({
+          ...item,
+          reply: sanitizeHumanReply(partial, {
+            slangAddressTerms: latestSlangTerms,
+          }),
+        }));
       }
-    }
+    );
 
     if (!result) {
       updateItem(id, (item) => ({

--- a/src/hooks/useEnhancedAISuggestions.ts
+++ b/src/hooks/useEnhancedAISuggestions.ts
@@ -3,6 +3,10 @@ import { useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useDocumentKnowledge } from '@/hooks/useDocumentKnowledge';
 import { sanitizeHumanReply } from '@/utils/sanitizeHumanReply';
+import {
+  RetryableGenerationError,
+  runWithGenerationRetry,
+} from '@/utils/generationRetryPolicy';
 import type { DocumentKnowledge } from '@/types/document';
 import type { HuddlePlay } from '@/utils/huddlePlayService';
 
@@ -62,12 +66,9 @@ export const useEnhancedAISuggestions = () => {
     isRegeneration: boolean = false,
     existingDocumentKnowledge: DocumentKnowledge[] = [],
     existingPastHuddles: PastHuddleWithSimilarity[] = [],
-    onToken?: (partial: string, options?: { slangAddressTerms?: string[] }) => void,
-    allowAutoRegenerate: boolean = true
+    onToken?: (partial: string, options?: { slangAddressTerms?: string[] }) => void
   ): Promise<GenerateReplyResult | null> => {
     const errorMessage = "Generation failed. Please click re-generate";
-    const maxAttempts = 5;
-    let lastError: unknown = null;
     let lastDocumentKnowledge = existingDocumentKnowledge;
     let lastPastHuddles = existingPastHuddles;
 
@@ -75,11 +76,12 @@ export const useEnhancedAISuggestions = () => {
     setError(null);
 
     try {
-      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-        try {
-          console.log(`🤖 DEBUG: Enhanced AI - Starting reply generation (attempt ${attempt}/${maxAttempts})...`);
-          console.log('📸 DEBUG: Screenshot text length:', screenshotText.length);
-          console.log('✏️ DEBUG: User draft length:', userDraft.length);
+      try {
+        return await runWithGenerationRetry(
+          async (attempt, maxAttempts) => {
+            console.log(`🤖 DEBUG: Enhanced AI - Starting reply generation (attempt ${attempt}/${maxAttempts})...`);
+            console.log('📸 DEBUG: Screenshot text length:', screenshotText.length);
+            console.log('✏️ DEBUG: User draft length:', userDraft.length);
 
           // Search for relevant documents based on screenshot + draft content
           let documentKnowledge: DocumentKnowledge[] = [];
@@ -93,7 +95,7 @@ export const useEnhancedAISuggestions = () => {
               documentKnowledge = await searchDocuments(searchQuery, 3);
               console.log(`📚 DEBUG: Found ${documentKnowledge.length} relevant document chunks`);
             } else {
-              documentKnowledge = existingDocumentKnowledge;
+              documentKnowledge = lastDocumentKnowledge;
               console.log(`📚 DEBUG: Re-using document knowledge on retry: ${documentKnowledge.length}`);
             }
           }
@@ -195,77 +197,68 @@ export const useEnhancedAISuggestions = () => {
 
           const trimmedReply = reply.trim();
           if (!trimmedReply) {
-            throw new Error('Empty reply from AI function');
+            throw new RetryableGenerationError('Empty reply from AI function');
           }
 
-          if (trimmedReply === errorMessage && allowAutoRegenerate) {
-            console.log('🔁 DEBUG: Auto-regenerating after fallback reply...');
-            return await generateReply(
-              screenshotText,
-              userDraft,
-              true,
-              documentKnowledgeUsed,
-              pastHuddles,
-              onToken,
-              false
+          if (trimmedReply === errorMessage) {
+            throw new RetryableGenerationError(
+              'AI function returned the fallback reply'
             );
-          } else if (trimmedReply === errorMessage) {
-            console.error('❌ DEBUG: Reply equals fallback error after attempts', {
-              attempts: attempt,
-              pastHuddlesCount: pastHuddles.length,
-              documentKnowledgeCount: documentKnowledgeUsed.length,
-              replyLength: trimmedReply.length,
-            });
           }
 
           // Ensure UI sees the final reply even if no tokens were streamed.
           if (reply && onToken) onToken(reply, { slangAddressTerms });
 
-          return {
-            reply,
-            pastHuddles,
-            documentKnowledge: documentKnowledgeUsed,
-            slangAddressTerms,
-          };
-        } catch (err) {
-          lastError = err;
-          console.error(
-            `❌ DEBUG: Enhanced AI attempt ${attempt}/${maxAttempts} failed`,
-            err instanceof Error ? err.message : err
-          );
-          if (attempt === maxAttempts) break;
-          console.log('🔁 DEBUG: Retrying generation...');
-        }
-      }
-
-      if (allowAutoRegenerate) {
-        console.log('🔁 DEBUG: Auto-regenerating after repeated failures...');
-        return await generateReply(
-          screenshotText,
-          userDraft,
-          true,
-          lastDocumentKnowledge,
-          lastPastHuddles,
-          onToken,
-          false
+            return {
+              reply,
+              pastHuddles,
+              documentKnowledge: documentKnowledgeUsed,
+              slangAddressTerms,
+            };
+          },
+          {
+            onRetry: ({
+              attempt,
+              nextAttempt,
+              maxAttempts,
+              delayMs,
+              error: retryError,
+            }) => {
+              console.warn('🔁 DEBUG: Retrying transient generation failure', {
+                attempt,
+                nextAttempt,
+                maxAttempts,
+                delayMs,
+                error:
+                  retryError instanceof Error
+                    ? retryError.message
+                    : String(retryError),
+              });
+            },
+          }
         );
+      } catch (generationError) {
+        console.error('❌ DEBUG: Generation failed after bounded retries', {
+          lastError:
+            generationError instanceof Error
+              ? generationError.message
+              : generationError,
+          lastErrorStack:
+            generationError instanceof Error
+              ? generationError.stack
+              : undefined,
+          screenshotLength: screenshotText.length,
+          draftLength: userDraft.length,
+        });
+
+        if (onToken) onToken(errorMessage);
+        setError(errorMessage);
+        return {
+          reply: errorMessage,
+          pastHuddles: lastPastHuddles,
+          documentKnowledge: lastDocumentKnowledge,
+        };
       }
-
-      console.error('❌ DEBUG: Generation failed after retries', {
-        attempts: maxAttempts,
-        lastError: lastError instanceof Error ? lastError.message : lastError,
-        lastErrorStack: lastError instanceof Error ? lastError.stack : undefined,
-        screenshotLength: screenshotText.length,
-        draftLength: userDraft.length,
-      });
-
-      if (onToken) onToken(errorMessage);
-      setError(errorMessage);
-      return {
-        reply: errorMessage,
-        pastHuddles: [],
-        documentKnowledge: [],
-      };
     } finally {
       setIsGenerating(false);
     }

--- a/src/utils/generationRetryPolicy.test.ts
+++ b/src/utils/generationRetryPolicy.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BASE_RETRY_DELAY_MS,
+  RetryableGenerationError,
+  runWithGenerationRetry,
+} from "./generationRetryPolicy";
+
+describe("runWithGenerationRetry", () => {
+  it("returns immediately after a successful first attempt", async () => {
+    const operation = vi.fn().mockResolvedValue("reply");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      runWithGenerationRetry(operation, { sleep })
+    ).resolves.toBe("reply");
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("retries one 500 response after a backoff", async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Function Error: 500 Internal Server Error"))
+      .mockResolvedValue("reply");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      runWithGenerationRetry(operation, { sleep })
+    ).resolves.toBe("reply");
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(sleep).toHaveBeenCalledWith(BASE_RETRY_DELAY_MS);
+  });
+
+  it("stops after two attempts when a 503 persists", async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValue(new Error("Function Error: 503 Service Unavailable"));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      runWithGenerationRetry(operation, { sleep })
+    ).rejects.toThrow("503");
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([400, 401, 403, 429])(
+    "does not retry an HTTP %s response",
+    async (status) => {
+      const operation = vi
+        .fn()
+        .mockRejectedValue(new Error(`Function Error: ${status}`));
+      const sleep = vi.fn().mockResolvedValue(undefined);
+
+      await expect(
+        runWithGenerationRetry(operation, { sleep })
+      ).rejects.toThrow(String(status));
+      expect(operation).toHaveBeenCalledTimes(1);
+      expect(sleep).not.toHaveBeenCalled();
+    }
+  );
+
+  it("retries a transient network failure once", async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValue("reply");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      runWithGenerationRetry(operation, { sleep })
+    ).resolves.toBe("reply");
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries an empty or fallback generation once", async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(new RetryableGenerationError("Empty reply"))
+      .mockResolvedValue("reply");
+
+    await expect(
+      runWithGenerationRetry(operation, {
+        sleep: vi.fn().mockResolvedValue(undefined),
+      })
+    ).resolves.toBe("reply");
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/utils/generationRetryPolicy.ts
+++ b/src/utils/generationRetryPolicy.ts
@@ -1,0 +1,91 @@
+export const MAX_GENERATION_ATTEMPTS = 2;
+export const BASE_RETRY_DELAY_MS = 750;
+const MAX_RETRY_DELAY_MS = 3_000;
+
+export class RetryableGenerationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RetryableGenerationError";
+  }
+}
+
+export const extractGenerationHttpStatus = (
+  error: unknown
+): number | null => {
+  const message = error instanceof Error ? error.message : String(error);
+  const match = message.match(/\b([1-5]\d{2})\b/);
+  return match ? Number(match[1]) : null;
+};
+
+export const isRetryableGenerationError = (error: unknown): boolean => {
+  if (error instanceof RetryableGenerationError) return true;
+
+  const status = extractGenerationHttpStatus(error);
+  if (status !== null) {
+    return [408, 500, 502, 503, 504].includes(status);
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return /network|fetch|timeout|timed out|abort|load failed|connection/i.test(
+    message
+  );
+};
+
+export const getGenerationRetryDelayMs = (attempt: number): number => {
+  const exponent = Math.max(0, attempt - 1);
+  return Math.min(
+    BASE_RETRY_DELAY_MS * 2 ** exponent,
+    MAX_RETRY_DELAY_MS
+  );
+};
+
+interface RetryContext {
+  attempt: number;
+  nextAttempt: number;
+  maxAttempts: number;
+  delayMs: number;
+  error: unknown;
+}
+
+interface GenerationRetryOptions {
+  onRetry?: (context: RetryContext) => void;
+  sleep?: (delayMs: number) => Promise<void>;
+}
+
+const defaultSleep = (delayMs: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, delayMs));
+
+export const runWithGenerationRetry = async <T>(
+  operation: (attempt: number, maxAttempts: number) => Promise<T>,
+  options: GenerationRetryOptions = {}
+): Promise<T> => {
+  const sleep = options.sleep ?? defaultSleep;
+
+  for (
+    let attempt = 1;
+    attempt <= MAX_GENERATION_ATTEMPTS;
+    attempt += 1
+  ) {
+    try {
+      return await operation(attempt, MAX_GENERATION_ATTEMPTS);
+    } catch (error) {
+      const canRetry =
+        attempt < MAX_GENERATION_ATTEMPTS &&
+        isRetryableGenerationError(error);
+
+      if (!canRetry) throw error;
+
+      const delayMs = getGenerationRetryDelayMs(attempt);
+      options.onRetry?.({
+        attempt,
+        nextAttempt: attempt + 1,
+        maxAttempts: MAX_GENERATION_ATTEMPTS,
+        delayMs,
+        error,
+      });
+      await sleep(delayMs);
+    }
+  }
+
+  throw new Error("Generation retry policy exhausted unexpectedly");
+};

--- a/src/utils/huddleCostPolicy.test.ts
+++ b/src/utils/huddleCostPolicy.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { shouldGenerateHuddleEmbedding } from "../../supabase/functions/shared/huddleCostPolicy";
+
+describe("shouldGenerateHuddleEmbedding", () => {
+  it("generates one reusable embedding for an initial reply", () => {
+    expect(shouldGenerateHuddleEmbedding(false)).toBe(true);
+  });
+
+  it("skips the unused embedding for a regeneration", () => {
+    expect(shouldGenerateHuddleEmbedding(true)).toBe(false);
+  });
+});

--- a/supabase/functions/enhanced-ai-suggestions/index.ts
+++ b/supabase/functions/enhanced-ai-suggestions/index.ts
@@ -4,6 +4,7 @@ import {
   HUDDLE_MODELS,
   selectHuddleReplyModel,
 } from "../shared/huddleModelRouting.ts";
+import { shouldGenerateHuddleEmbedding } from "../shared/huddleCostPolicy.ts";
 import { stopWords } from "../shared/stopWords.ts";
 
 const { createClient } = supabaseJs;
@@ -695,41 +696,54 @@ serve(async (req: Request) => {
           /what.*work/.test(combined)
         );
       })();
-      const sharedEmbeddingPromise = (async () => {
-        try {
-          const embeddingController = new AbortController();
-          const embeddingTimeout = setTimeout(
-            () => embeddingController.abort(),
-            BASE_OPENAI_TIMEOUT_MS
-          );
-          const embeddingResponse = await fetch(
-            "https://api.openai.com/v1/embeddings",
-            {
-              method: "POST",
-              headers: {
-                Authorization: `Bearer ${openaiApiKey}`,
-                "Content-Type": "application/json",
-              },
-              signal: embeddingController.signal,
-              body: JSON.stringify({
-                input: combinedTextForEmbedding,
-                model: "text-embedding-3-small",
-              }),
-            }
-          );
-          clearTimeout(embeddingTimeout);
-          const embeddingData = await embeddingResponse.json();
-          const embedding = embeddingData.data?.[0]?.embedding;
-          console.log(
-            "🧠 DEBUG: Shared embedding generated. Length:",
-            embedding?.length || 0
-          );
-          return embedding;
-        } catch (err) {
-          console.error("❌ DEBUG: Shared embedding generation failed:", err);
-          return null;
-        }
-      })();
+      const shouldGenerateEmbedding = shouldGenerateHuddleEmbedding(
+        Boolean(isRegeneration)
+      );
+      const sharedEmbeddingPromise: Promise<number[] | null> =
+        shouldGenerateEmbedding
+          ? (async () => {
+              try {
+                const embeddingController = new AbortController();
+                const embeddingTimeout = setTimeout(
+                  () => embeddingController.abort(),
+                  BASE_OPENAI_TIMEOUT_MS
+                );
+                const embeddingResponse = await fetch(
+                  "https://api.openai.com/v1/embeddings",
+                  {
+                    method: "POST",
+                    headers: {
+                      Authorization: `Bearer ${openaiApiKey}`,
+                      "Content-Type": "application/json",
+                    },
+                    signal: embeddingController.signal,
+                    body: JSON.stringify({
+                      input: combinedTextForEmbedding,
+                      model: "text-embedding-3-small",
+                    }),
+                  }
+                );
+                clearTimeout(embeddingTimeout);
+                const embeddingData = await embeddingResponse.json();
+                const embedding = embeddingData.data?.[0]?.embedding;
+                console.log(
+                  "🧠 DEBUG: Shared embedding generated. Length:",
+                  embedding?.length || 0
+                );
+                return embedding;
+              } catch (err) {
+                console.error(
+                  "❌ DEBUG: Shared embedding generation failed:",
+                  err
+                );
+                return null;
+              }
+            })()
+          : Promise.resolve(null);
+
+      if (!shouldGenerateEmbedding) {
+        console.log("ℹ️ DEBUG: Skipping unused embedding for regeneration.");
+      }
 
       const similarHuddlesPromise =
         userId && !isRegeneration
@@ -1091,6 +1105,7 @@ Refine this draft to make it better without inventing missing details.`;
         max_completion_tokens: maxTokens,
         reasoning_effort: reasoningEffort,
         stream: true,
+        stream_options: { include_usage: true },
       };
 
       if (!chatModel.startsWith("gpt-5")) {
@@ -1140,6 +1155,12 @@ Refine this draft to make it better without inventing missing details.`;
       let streamErrored = false;
       let sawDone = false;
       let controllerClosed = false;
+      let streamUsage: {
+        prompt_tokens?: number;
+        completion_tokens?: number;
+        total_tokens?: number;
+        completion_tokens_details?: { reasoning_tokens?: number };
+      } | null = null;
 
       const stream = new ReadableStream({
         start(controller) {
@@ -1193,6 +1214,17 @@ Refine this draft to make it better without inventing missing details.`;
             if (controllerClosed) return;
             sawDone = true;
             ensureFallback();
+            if (streamUsage) {
+              console.log("📈 Huddle OpenAI usage:", {
+                model: chatModel,
+                modelRoute,
+                promptTokens: streamUsage.prompt_tokens,
+                completionTokens: streamUsage.completion_tokens,
+                reasoningTokens:
+                  streamUsage.completion_tokens_details?.reasoning_tokens,
+                totalTokens: streamUsage.total_tokens,
+              });
+            }
             safeEnqueue(JSON.stringify({ type: "done" }) + "\n");
             safeClose();
             resolveStreamComplete?.();
@@ -1216,6 +1248,9 @@ Refine this draft to make it better without inventing missing details.`;
                 : trimmed;
               try {
                 const parsed = JSON.parse(payloadText);
+                if (parsed.usage) {
+                  streamUsage = parsed.usage;
+                }
                 const deltaRaw = parsed.choices?.[0]?.delta?.content;
                 const delta = extractDeltaText(deltaRaw);
                 if (delta) {

--- a/supabase/functions/shared/huddleCostPolicy.ts
+++ b/supabase/functions/shared/huddleCostPolicy.ts
@@ -1,0 +1,3 @@
+export const shouldGenerateHuddleEmbedding = (
+  isRegeneration: boolean
+): boolean => !isRegeneration;


### PR DESCRIPTION
## What changed
- cap each Huddle generation action at two attempts (the initial call plus one backoff retry)
- retry only transient 5xx/network/empty-response failures, and do not retry quota, authentication, or bad-request responses
- remove the Batch Huddles outer retry loop and the automatic five-attempt regeneration cascade
- skip the unused embedding request for explicit regenerations
- record safe per-request OpenAI token usage in Edge Function logs

## Why
A failed generation could previously fan out into up to 10 Edge Function calls, or up to 20 from Batch Huddles. Each regeneration also generated an embedding that was never used. This amplified API spend while no successful `huddle_plays` row was inserted.

## Impact
A single action now makes at most two generation calls. Explicit regenerations keep the higher-quality fallback model but no longer incur an unnecessary embedding. Future token usage is visible in server logs for cost reconciliation.

## Validation
- `npm test` — 26 tests passed
- `npm run build` — passed
- changed-file ESLint — passed
- `git diff --check` — passed

The repository-wide lint command still reports five pre-existing errors in unrelated files.