### PR TITLE
Simplify reply UI and restore HTTP localhost

### DIFF
--- a/src/components/GeneratedReplySection.tsx
+++ b/src/components/GeneratedReplySection.tsx
@@ -2,15 +2,11 @@
 import React from 'react';
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Check, RefreshCcw, Copy, Sparkles } from "lucide-react";
+import { RefreshCcw, Copy } from "lucide-react";
 import { ToneSelector } from "@/components/ToneSelector";
 import { useTypingEffect } from '@/hooks/useTypingEffect';
 import { Textarea } from "@/components/ui/textarea";
-import {
-  getStyleProfileSignals,
-  getStyleProfileStrength,
-  type StyleProfile,
-} from "@/types/styleProfile";
+import type { StyleProfile } from "@/types/styleProfile";
 
 interface GeneratedReplySectionProps {
   generatedReply: string;
@@ -43,12 +39,9 @@ export const GeneratedReplySection: React.FC<GeneratedReplySectionProps> = ({
   onReset,
   copiedFeedback,
   forceShow = false,
-  styleProfile,
 }) => {
   const displayedReply = useTypingEffect(generatedReply, 20);
   const showGenerationLoader = showInlineLoader && isGenerating && !isAdjustingTone;
-  const styleStrength = getStyleProfileStrength(styleProfile || null);
-  const styleSignals = getStyleProfileSignals(styleProfile || null);
 
   // Keep the section visible while generating or adjusting, even before text arrives.
   if (!forceShow && !generatedReply && !isGenerating && !isAdjustingTone) return null;
@@ -87,40 +80,6 @@ export const GeneratedReplySection: React.FC<GeneratedReplySectionProps> = ({
                   animation: "shimmer 1.6s linear infinite"
                 }}
               />
-            </div>
-          </div>
-        )}
-
-        {styleProfile && (
-          <div className="flex flex-col gap-3 rounded-2xl border border-[#c49b5d]/25 bg-[#c49b5d]/10 p-4 dark:border-[#c49b5d]/18 dark:bg-[#c49b5d]/[0.07] sm:flex-row sm:items-center">
-            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-[#c49b5d] text-[#071326] shadow-sm">
-              {isGenerating ? (
-                <Sparkles className="h-4 w-4 animate-pulse" />
-              ) : (
-                <Check className="h-4 w-4" />
-              )}
-            </span>
-            <div className="min-w-0 flex-1">
-              <p className="text-sm font-semibold text-[#3f3428] dark:text-[#f2e5d5]">
-                {isGenerating
-                  ? "Matching your voice profile"
-                  : "Shaped with your voice profile"}
-              </p>
-              <p className="mt-0.5 text-xs leading-relaxed text-[#77634d] dark:text-[#bfae9b]">
-                {isGenerating
-                  ? "Balancing your usual cadence, phrasing, and accepted replies."
-                  : `${styleStrength.label} match based on ${styleProfile.huddle_count} saved replies.`}
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-1.5 sm:max-w-[44%] sm:justify-end">
-              {styleSignals.slice(0, 3).map((signal) => (
-                <span
-                  key={signal}
-                  className="rounded-full bg-white/60 px-2.5 py-1 text-[11px] font-medium text-[#6b4c24] dark:bg-white/[0.06] dark:text-[#dec08f]"
-                >
-                  {signal}
-                </span>
-              ))}
             </div>
           </div>
         )}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,6 @@ import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
-import basicSsl from "@vitejs/plugin-basic-ssl";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -27,7 +26,6 @@ export default defineConfig(({ mode }) => {
     },
     plugins: [
       react(),
-      basicSsl(),
       mode === 'development' &&
       componentTagger(),
     ].filter(Boolean),


### PR DESCRIPTION
## What changed

- Removed the visible voice-profile matching panel from the generated reply section while keeping the profile active in generation.
- Restored the local Vite server to standard HTTP by removing the self-signed HTTPS plugin.

## Why

The profile panel added visual noise after generation, and the local HTTPS certificate caused the in-app browser to report that localhost was unreachable.

## Impact

- Generated replies have a cleaner, more focused presentation.
- Local development works reliably at `http://localhost:8080/`.
- Voice-profile data continues to influence generated replies.

## Validation

- 47 tests passed
- ESLint passed
- TypeScript checks passed
- Production build passed