### PR TITLE
Remove unintended Android action bar

### DIFF
--- a/android/app/src/main/res/values-v27/styles.xml
+++ b/android/app/src/main/res/values-v27/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="AppTheme.NoActionBar">
+    <style name="AppTheme.NoActionBar" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowLightNavigationBar">false</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -22,5 +22,6 @@
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
         <item name="android:background">@drawable/splash</item>
         <item name="windowSplashScreenBackground">@color/brand_ivory</item>
+        <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
     </style>
 </resources>


### PR DESCRIPTION
## What changed

- explicitly keep the Android 27+ theme on the `NoActionBar` parent
- hand the splash theme back to the app's `NoActionBar` theme after launch

## Why

The Android 27+ resource override implicitly inherited `AppTheme`, whose parent includes a native action bar. On affected phones this rendered an unintended banner above the WebView with a truncated app title and distorted icon.

## Impact

The Huddle Assistant content now begins directly below the system status bar with no duplicate native banner. The change is limited to Android theme resources and does not affect the web application.

## Validation

- `npm run check` — 47 tests, lint, type-check, and production build passed
- Android debug APK built successfully with Java 17
- installed and launched on the Android emulator
- emulator screenshot verified the banner is gone
- live UI hierarchy verified `action_bar_container` is absent
