### PR TITLE
Prepare Android tester build 2

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "com.doubleheelix.huddleassistant"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.


### PR DESCRIPTION
## What changed

- increment Android `versionCode` from 1 to 2
- update `versionName` from 1.0 to 1.0.1

## Why

Google Play requires a higher version code for every update. This release bump makes the native action-bar fix from #108 eligible for upload to the internal-testing track.

## Impact

Testers can receive the corrected build as version 1.0.1 after the signed bundle is uploaded to Google Play internal testing.

## Validation

- signed release AAB built successfully
- release manifest verified as `com.doubleheelix.huddleassistant`, version code 2, version name 1.0.1
- bundle signature verification completed
