### PR TITLE
Preserve reply paragraph formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,5 @@ jobs:
         with:
           deno-version: v2.x
       - run: deno check supabase/functions/*/index.ts
+      - run: deno test supabase/functions/shared/replyFormatting_test.ts
       - run: npm run build

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "com.doubleheelix.huddleassistant"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2
-        versionName "1.0.1"
+        versionCode 3
+        versionName "1.0.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/src/components/HistoryTab.tsx
+++ b/src/components/HistoryTab.tsx
@@ -229,8 +229,8 @@ export const HistoryTab = () => {
                       Your draft
                     </p>
                     <p
-                      className={`text-sm leading-relaxed text-[#776b5d] dark:text-[#b4a89a] ${
-                        expanded ? "whitespace-pre-wrap" : "line-clamp-3"
+                      className={`whitespace-pre-wrap text-sm leading-relaxed text-[#776b5d] dark:text-[#b4a89a] ${
+                        expanded ? "" : "line-clamp-3"
                       }`}
                     >
                       {huddle.user_draft || "Draft unavailable"}
@@ -242,8 +242,8 @@ export const HistoryTab = () => {
                       Final reply
                     </p>
                     <p
-                      className={`text-[15px] leading-7 text-[#29231c] dark:text-[#f4efe7] ${
-                        expanded ? "whitespace-pre-wrap" : "line-clamp-3"
+                      className={`whitespace-pre-wrap text-[15px] leading-7 text-[#29231c] dark:text-[#f4efe7] ${
+                        expanded ? "" : "line-clamp-3"
                       }`}
                     >
                       {reply || "Reply unavailable"}

--- a/src/components/PastHuddlesTab.tsx
+++ b/src/components/PastHuddlesTab.tsx
@@ -314,7 +314,7 @@ const VirtualizedHuddleList = ({
                       Your Draft:
                     </p>
                     <p
-                      className={`text-gray-800 dark:text-gray-200 text-sm font-sans ${
+                      className={`whitespace-pre-wrap text-gray-800 dark:text-gray-200 text-sm font-sans ${
                         !isDraftExpanded(huddle.id) && 'line-clamp-2'
                       }`}
                     >
@@ -336,7 +336,7 @@ const VirtualizedHuddleList = ({
                       {huddle.final_reply ? 'Final Reply:' : 'Generated Reply:'}
                     </p>
                     <div className="bg-gray-100 dark:bg-gray-900 p-3 rounded-lg border border-gray-200 dark:border-gray-700">
-                      <p className="text-gray-900 dark:text-white text-sm font-sans">
+                      <p className="whitespace-pre-wrap text-gray-900 dark:text-white text-sm font-sans">
                         {huddle.final_reply || huddle.generated_reply}
                       </p>
                     </div>

--- a/src/components/PeopleTab.tsx
+++ b/src/components/PeopleTab.tsx
@@ -426,7 +426,7 @@ export const PeopleTab = () => {
                               </Badge>
                             )}
                           </div>
-                          <div className="text-sm text-gray-200 font-sans line-clamp-2">
+                          <div className="whitespace-pre-wrap text-sm text-gray-200 font-sans line-clamp-2">
                             {huddle.user_draft}
                           </div>
                           <div className="flex items-start gap-2 text-xs text-gray-400 font-sans">
@@ -477,7 +477,7 @@ export const PeopleTab = () => {
                             </div>
                           </div>
 
-                          <div className="bg-gray-800/60 border border-gray-700/60 rounded-md p-2 text-xs text-white font-sans">
+                          <div className="whitespace-pre-wrap bg-gray-800/60 border border-gray-700/60 rounded-md p-2 text-xs text-white font-sans">
                             {huddle.final_reply || huddle.generated_reply}
                           </div>
                         </div>

--- a/src/utils/sanitizeHumanReply.test.ts
+++ b/src/utils/sanitizeHumanReply.test.ts
@@ -12,6 +12,23 @@ describe("sanitizeHumanReply", () => {
     expect(sanitizeHumanReply(input)).toBe("hello world!");
   });
 
+  it("preserves line breaks and paragraph boundaries", () => {
+    const input = "First line.\nSecond line.\n\nSecond paragraph.";
+    expect(sanitizeHumanReply(input)).toBe(input);
+  });
+
+  it("normalizes pasted line endings and excessive blank lines", () => {
+    const input = "First paragraph.\r\n\r\n\r\nSecond paragraph.";
+    expect(sanitizeHumanReply(input)).toBe(
+      "First paragraph.\n\nSecond paragraph."
+    );
+  });
+
+  it("normalizes tabs without removing line breaks", () => {
+    const input = "First\tline.\n\nSecond\tline.";
+    expect(sanitizeHumanReply(input)).toBe("First line.\n\nSecond line.");
+  });
+
   it("normalizes fancy quotes and ellipsis", () => {
     const input = "“wow…” they said ‘cool’";
     expect(sanitizeHumanReply(input)).toBe('"wow..." they said \'cool\'');

--- a/src/utils/sanitizeHumanReply.ts
+++ b/src/utils/sanitizeHumanReply.ts
@@ -40,6 +40,8 @@ const stripControlChars = (value: string) =>
   Array.from(value)
     .filter((char) => {
       const code = char.charCodeAt(0);
+      // Tabs and line endings are intentional formatting, not unsafe controls.
+      if (code === 9 || code === 10 || code === 13) return true;
       return !((code >= 0 && code <= 31) || (code >= 127 && code <= 159));
     })
     .join("");

--- a/supabase/functions/enhanced-ai-suggestions/index.ts
+++ b/supabase/functions/enhanced-ai-suggestions/index.ts
@@ -13,6 +13,7 @@ import {
 } from "../shared/huddleModelRouting.ts";
 import { shouldGenerateHuddleEmbedding } from "../shared/huddleCostPolicy.ts";
 import { stopWords } from "../shared/stopWords.ts";
+import { sanitizeReply } from "../shared/replyFormatting.ts";
 
 // Exclude obvious system/prompt words from phrase extraction.
 const PHRASE_BANLIST = new Set([
@@ -391,10 +392,6 @@ function median(nums: number[]): number {
   return sorted[mid];
 }
 
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function buildSlangAddressTerms(terms: string[] = []): string[] {
   const merged = [...defaultSlangAddressTerms, ...terms];
   return Array.from(
@@ -406,62 +403,11 @@ function buildSlangAddressTerms(terms: string[] = []): string[] {
   );
 }
 
-function buildSlangAddressRegex(terms: string[]): RegExp | null {
-  if (!terms.length) return null;
-  const escaped = terms.map(escapeRegex).join("|");
-  return new RegExp(`,\\s+(${escaped})(?=$|\\s|[.!?])`, "gi");
-}
-
-function removeVocativeComma(text: string, terms: string[] = []): string {
-  if (!terms.length) return text;
-  const regex = buildSlangAddressRegex(terms);
-  if (!regex) return text;
-  return text.replace(regex, " $1");
-}
-
 function topItems(map: Map<string, number>, limit: number): string[] {
   return Array.from(map.entries())
     .sort((a, b) => b[1] - a[1])
     .slice(0, limit)
     .map(([key]) => key);
-}
-
-function stripControlChars(value: string): string {
-  return Array.from(value)
-    .filter((char) => {
-      const code = char.charCodeAt(0);
-      return !((code >= 0 && code <= 31) || (code >= 127 && code <= 159));
-    })
-    .join("");
-}
-
-// Remove control characters and odd symbols that occasionally appear in model output.
-function sanitizeReply(
-  text: string,
-  options: { trim?: boolean; slangAddressTerms?: string[] } = {}
-): string {
-  if (!text) return "";
-  let cleaned = text;
-
-  cleaned = stripControlChars(cleaned)
-    .replace(/\r\n/g, "\n")
-    .replace(/\r/g, "\n")
-    .replace(/[^\S\n]+/gu, " ")
-    // Keep letters, numbers, punctuation, spaces, line breaks, and emoji; drop other symbols
-    .replace(
-      /[^\p{L}\p{N}\p{P}\p{Zs}\n\r\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu,
-      " "
-    )
-    // Normalize runs of spaces/tabs
-    .replace(/[ \t]+/g, " ")
-    // Limit excessive blank lines
-    .replace(/\n{3,}/g, "\n\n");
-
-  if (options.slangAddressTerms?.length) {
-    cleaned = removeVocativeComma(cleaned, options.slangAddressTerms);
-  }
-
-  return options.trim ? cleaned.trim() : cleaned;
 }
 
 function computeStyleFingerprint(drafts: string[]): StyleFingerprint {
@@ -1450,6 +1396,7 @@ Input handling (critical):
 - The supplied input type is "${effectiveDraftInputMode}".
 - If it is "draft": treat the user's wording as the primary voice evidence. Preserve every concrete fact, commitment, question, boundary, emotional stance, and recognizable phrase unless it is genuinely unclear. Refine conservatively; do not replace the user's personality with generic polish.
 - If it is "direction": treat the input as instructions for the final message, not text to repeat. Build the complete reply from the stated goal, the conversation, accepted-reply examples, and the style profile. Never expose planning language such as "tell them", "ask him", or "keep it casual" in the final reply.
+- Preserve intentional line breaks and paragraph boundaries. For a draft, keep the same paragraph structure. For a direction, treat separate lines or paragraphs as separate ideas and return readable paragraph breaks.
 - If the classification appears uncertain, behave conservatively: preserve supplied wording and never invent missing personal details.
 
 Authenticity evidence priority:
@@ -1484,6 +1431,7 @@ Context Tools:
 
 Output Rules:
 - Aim for 2–4 sentences; exceed only if necessary for clarity (max 10).
+- Never collapse separate paragraphs into one block of text.
 - Only return the final message—no commentary, labels, analysis, or quotation marks.
 - The result should feel organic and human, not over-engineered.
 - Prioritize clarity, connection, and authenticity.`;
@@ -2581,7 +2529,7 @@ ${
         messages: [
           {
             role: "system",
-            content: `${instruction}. Keep the core message and meaning intact, just adjust the tone. Respond with only the adjusted message, no explanations.`,
+            content: `${instruction}. Keep the core message and meaning intact, just adjust the tone. Preserve every existing line break and paragraph boundary; do not merge paragraphs. Respond with only the adjusted message, no explanations.`,
           },
           {
             role: "user",

--- a/supabase/functions/shared/replyFormatting.ts
+++ b/supabase/functions/shared/replyFormatting.ts
@@ -1,0 +1,47 @@
+const escapeRegex = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const buildSlangAddressRegex = (terms: string[]): RegExp | null => {
+  if (!terms.length) return null;
+  const escaped = terms.map(escapeRegex).join("|");
+  return new RegExp(`,\\s+(${escaped})(?=$|\\s|[.!?])`, "gi");
+};
+
+const removeVocativeComma = (text: string, terms: string[] = []): string => {
+  const regex = buildSlangAddressRegex(terms);
+  return regex ? text.replace(regex, " $1") : text;
+};
+
+const stripUnsafeControlChars = (value: string): string =>
+  Array.from(value)
+    .filter((char) => {
+      const code = char.charCodeAt(0);
+      // Preserve tabs, LF, and CR so whitespace normalization can retain layout.
+      if (code === 9 || code === 10 || code === 13) return true;
+      return !((code >= 0 && code <= 31) || (code >= 127 && code <= 159));
+    })
+    .join("");
+
+export function sanitizeReply(
+  text: string,
+  options: { trim?: boolean; slangAddressTerms?: string[] } = {},
+): string {
+  if (!text) return "";
+
+  let cleaned = stripUnsafeControlChars(text)
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/[^\S\n]+/gu, " ")
+    .replace(
+      /[^\p{L}\p{N}\p{P}\p{Zs}\n\r\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu,
+      " ",
+    )
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n");
+
+  if (options.slangAddressTerms?.length) {
+    cleaned = removeVocativeComma(cleaned, options.slangAddressTerms);
+  }
+
+  return options.trim ? cleaned.trim() : cleaned;
+}

--- a/supabase/functions/shared/replyFormatting_test.ts
+++ b/supabase/functions/shared/replyFormatting_test.ts
@@ -1,0 +1,32 @@
+import { sanitizeReply } from "./replyFormatting.ts";
+
+function assertEquals(actual: string, expected: string): void {
+  if (actual !== expected) {
+    throw new Error(
+      `Expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+Deno.test("preserves intentional reply line breaks", () => {
+  const input = "First line.\nSecond line.\n\nSecond paragraph.";
+  assertEquals(sanitizeReply(input, { trim: true }), input);
+});
+
+Deno.test("preserves newline-only streaming chunks", () => {
+  assertEquals(sanitizeReply("\n\n"), "\n\n");
+});
+
+Deno.test("normalizes pasted line endings and excessive blank lines", () => {
+  assertEquals(
+    sanitizeReply("First.\r\n\r\n\r\nSecond.", { trim: true }),
+    "First.\n\nSecond.",
+  );
+});
+
+Deno.test("removes unsafe controls without joining paragraphs", () => {
+  assertEquals(
+    sanitizeReply("First.\u0007\n\nSecond.", { trim: true }),
+    "First.\n\nSecond.",
+  );
+});


### PR DESCRIPTION
## What changed
- preserve intentional line breaks and paragraph boundaries in client and Supabase reply sanitizers
- keep paragraph structure during initial generation, regeneration, tone adjustment, streaming, batch mode, history, and copy/save flows
- add client and Deno regression tests for LF, CRLF, streaming newline chunks, tabs, unsafe controls, and excessive blank lines
- prepare Android version 1.0.2 (build 3) for internal testing

## Root cause
Both the app and Edge Function treated every ASCII control character as unsafe, which removed LF and CR before later newline-normalization code could run. Model-produced paragraphs were therefore concatenated.

## Validation
- `npm run check` (50 tests, lint, typecheck, production build)
- `deno test supabase/functions/shared/replyFormatting_test.ts` (4 tests)
- `deno check supabase/functions/enhanced-ai-suggestions/index.ts`
- `npm run android:debug`